### PR TITLE
Revert "LPS-48313 Make it work whether I type "ant jar" or "ant war""

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1580,34 +1580,6 @@ Please find a solution that does not require portal-impl.jar.
 							/>
 						</then>
 					</if>
-
-					<if>
-						<available file="@{module.dir}/docroot/WEB-INF/portlet.xml" />
-						<then>
-							<tstamp>
-								<format property="tstamp.value" pattern="yyyyMMddkkmmssSSS" />
-							</tstamp>
-
-							<move file="${plugin.file}" tofile="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}.war" />
-
-							<direct-deploy-portlet-cmd
-								direct.deploy.dir="${tstamp.value}"
-								module.dir="@{module.dir}"
-							/>
-
-							<zip destfile="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}.war" update="true">
-								<zipfileset
-									dir="${tstamp.value}/${plugin.name}"
-									fullpath="WEB-INF/web.xml"
-									includes="WEB-INF/web.xml"
-								/>
-							</zip>
-
-							<move file="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}.war" tofile="${plugin.file}" />
-
-							<delete dir="${tstamp.value}" />
-						</then>
-					</if>
 				</then>
 				<else>
 					<jar
@@ -2485,6 +2457,34 @@ for (String path : paths) {
 						module.dirs="@{module.dir}"
 						target.name="jar"
 					/>
+
+					<if>
+						<available file="@{module.dir}/docroot/WEB-INF/portlet.xml" />
+						<then>
+							<tstamp>
+								<format property="tstamp.value" pattern="yyyyMMddkkmmssSSS" />
+							</tstamp>
+
+							<move file="${plugin.file}" tofile="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}.war" />
+
+							<direct-deploy-portlet-cmd
+								direct.deploy.dir="${tstamp.value}"
+								module.dir="@{module.dir}"
+							/>
+
+							<zip destfile="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}.war" update="true">
+								<zipfileset
+									dir="${tstamp.value}/${plugin.name}"
+									fullpath="WEB-INF/web.xml"
+									includes="WEB-INF/web.xml"
+								/>
+							</zip>
+
+							<move file="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}.war" tofile="${plugin.file}" />
+
+							<delete dir="${tstamp.value}" />
+						</then>
+					</if>
 				</then>
 				<else>
 					<if>


### PR DESCRIPTION
This reverts commit b33f65eff3745667c3c66852307a0155410d9258. OSGi modules with a portlet structure fail to deploy. This logic considers that those modules are deployed as wars, but they are actually deployed as jars.
